### PR TITLE
Reduce memory allocations

### DIFF
--- a/crate/abcrypt/CHANGELOG.adoc
+++ b/crate/abcrypt/CHANGELOG.adoc
@@ -23,6 +23,11 @@ project adheres to https://semver.org/[Semantic Versioning].
 * Add convenience functions for using `Encryptor` and `Decryptor`
   ({pull-request-url}/22[#22])
 
+=== Changed
+
+* Change to store the plaintext and the ciphertext as `slice` in `Encryptor`
+  and `Decryptor` ({pull-request-url}/25[#25])
+
 == {project-url}/releases/tag/abcrypt-v0.1.0[0.1.0] - 2023-08-25
 
 === Added

--- a/crate/abcrypt/benches/decrypt.rs
+++ b/crate/abcrypt/benches/decrypt.rs
@@ -23,7 +23,7 @@ const TEST_DATA_ENC: &[u8] = include_bytes!("../tests/data/data.txt.enc");
 #[bench]
 fn decrypt(b: &mut Bencher) {
     b.iter(|| {
-        Decryptor::new(TEST_DATA_ENC, PASSPHRASE)
+        Decryptor::new(&TEST_DATA_ENC, PASSPHRASE)
             .and_then(Decryptor::decrypt_to_vec)
             .unwrap()
     });

--- a/crate/abcrypt/benches/encrypt.rs
+++ b/crate/abcrypt/benches/encrypt.rs
@@ -22,7 +22,7 @@ const TEST_DATA: &[u8] = include_bytes!("../tests/data/data.txt");
 #[bench]
 fn encrypt(b: &mut Bencher) {
     b.iter(|| {
-        Encryptor::with_params(TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
+        Encryptor::with_params(&TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
             .map(Encryptor::encrypt_to_vec)
             .unwrap()
     });

--- a/crate/abcrypt/examples/decrypt.rs
+++ b/crate/abcrypt/examples/decrypt.rs
@@ -40,7 +40,7 @@ fn main() -> anyhow::Result<()> {
         .with_prompt("Enter passphrase")
         .interact()
         .context("could not read passphrase")?;
-    let cipher = match abcrypt::Decryptor::new(ciphertext, passphrase) {
+    let cipher = match abcrypt::Decryptor::new(&ciphertext, passphrase) {
         c @ Err(abcrypt::Error::InvalidHeaderMac(_)) => c.context("passphrase is incorrect"),
         c => c.with_context(|| format!("the header in {} is invalid", opt.input.display())),
     }?;

--- a/crate/abcrypt/examples/encrypt.rs
+++ b/crate/abcrypt/examples/encrypt.rs
@@ -55,7 +55,7 @@ fn main() -> anyhow::Result<()> {
         .context("could not read passphrase")?;
     let params =
         abcrypt::argon2::Params::new(opt.memory_size, opt.iterations, opt.parallelism, None)?;
-    let cipher = abcrypt::Encryptor::with_params(plaintext, passphrase, params)?;
+    let cipher = abcrypt::Encryptor::with_params(&plaintext, passphrase, params)?;
     let ciphertext = cipher.encrypt_to_vec();
     std::fs::write(opt.output, ciphertext)
         .with_context(|| format!("could not write the result to {}", opt.input.display()))?;

--- a/crate/abcrypt/src/error.rs
+++ b/crate/abcrypt/src/error.rs
@@ -69,12 +69,12 @@ impl std::error::Error for Error {
 /// ```
 /// use abcrypt::{Decryptor, Encryptor};
 ///
-/// fn encrypt(data: &[u8], passphrase: &[u8]) -> abcrypt::Result<Vec<u8>> {
-///     Encryptor::new(data, passphrase).map(Encryptor::encrypt_to_vec)
+/// fn encrypt(plaintext: &[u8], passphrase: &[u8]) -> abcrypt::Result<Vec<u8>> {
+///     Encryptor::new(&plaintext, passphrase).map(Encryptor::encrypt_to_vec)
 /// }
 ///
-/// fn decrypt(data: &[u8], passphrase: &[u8]) -> abcrypt::Result<Vec<u8>> {
-///     Decryptor::new(data, passphrase).and_then(Decryptor::decrypt_to_vec)
+/// fn decrypt(ciphertext: &[u8], passphrase: &[u8]) -> abcrypt::Result<Vec<u8>> {
+///     Decryptor::new(&ciphertext, passphrase).and_then(Decryptor::decrypt_to_vec)
 /// }
 ///
 /// let data = b"Hello, world!";

--- a/crate/abcrypt/src/lib.rs
+++ b/crate/abcrypt/src/lib.rs
@@ -23,7 +23,7 @@
 //! assert_ne!(ciphertext, data);
 //!
 //! // And decrypt it back.
-//! let plaintext = Decryptor::new(ciphertext, passphrase)
+//! let plaintext = Decryptor::new(&ciphertext, passphrase)
 //!     .and_then(Decryptor::decrypt_to_vec)
 //!     .unwrap();
 //! assert_eq!(plaintext, data);

--- a/crate/abcrypt/src/params.rs
+++ b/crate/abcrypt/src/params.rs
@@ -11,13 +11,13 @@ use crate::{format::Header, Result};
 pub struct Params(argon2::Params);
 
 impl Params {
-    /// Creates a new instance of the Argon2 parameters from `data`.
+    /// Creates a new instance of the Argon2 parameters from `ciphertext`.
     ///
     /// # Errors
     ///
     /// Returns [`Err`] if any of the following are true:
     ///
-    /// - `data` is shorter than 156 bytes.
+    /// - `ciphertext` is shorter than 156 bytes.
     /// - The magic number is invalid.
     /// - The version number is the unrecognized abcrypt version number.
     /// - The Argon2 parameters are invalid.
@@ -37,8 +37,8 @@ impl Params {
     ///
     /// assert!(Params::new(ciphertext).is_ok());
     /// ```
-    pub fn new(data: impl AsRef<[u8]>) -> Result<Self> {
-        let params = Header::parse(data.as_ref()).map(|h| h.params())?;
+    pub fn new(ciphertext: impl AsRef<[u8]>) -> Result<Self> {
+        let params = Header::parse(ciphertext.as_ref()).map(|h| h.params())?;
         Ok(Self(params))
     }
 

--- a/crate/abcrypt/tests/encrypt.rs
+++ b/crate/abcrypt/tests/encrypt.rs
@@ -18,14 +18,14 @@ const TEST_DATA: &[u8] = include_bytes!("data/data.txt");
 fn success() {
     {
         let cipher =
-            Encryptor::with_params(TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
+            Encryptor::with_params(&TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
                 .unwrap();
         let mut buf = vec![u8::default(); cipher.out_len()];
         cipher.encrypt(&mut buf);
         assert_ne!(buf, TEST_DATA);
         assert_eq!(buf.len(), TEST_DATA.len() + 156);
 
-        let plaintext = Decryptor::new(buf, PASSPHRASE)
+        let plaintext = Decryptor::new(&buf, PASSPHRASE)
             .and_then(Decryptor::decrypt_to_vec)
             .unwrap();
         assert_eq!(plaintext, TEST_DATA);
@@ -33,13 +33,13 @@ fn success() {
 
     {
         let ciphertext =
-            Encryptor::with_params(TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
+            Encryptor::with_params(&TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
                 .map(Encryptor::encrypt_to_vec)
                 .unwrap();
         assert_ne!(ciphertext, TEST_DATA);
         assert_eq!(ciphertext.len(), TEST_DATA.len() + 156);
 
-        let plaintext = Decryptor::new(ciphertext, PASSPHRASE)
+        let plaintext = Decryptor::new(&ciphertext, PASSPHRASE)
             .and_then(Decryptor::decrypt_to_vec)
             .unwrap();
         assert_eq!(plaintext, TEST_DATA);
@@ -50,7 +50,7 @@ fn success() {
 #[should_panic(expected = "source slice length (30) does not match destination slice length (29)")]
 fn invalid_output_length() {
     let cipher =
-        Encryptor::with_params(TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
+        Encryptor::with_params(&TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
             .unwrap();
     let mut buf = vec![u8::default(); cipher.out_len() - 1];
     cipher.encrypt(&mut buf);
@@ -59,7 +59,7 @@ fn invalid_output_length() {
 #[test]
 fn minimum_output_length() {
     let cipher =
-        Encryptor::with_params([], PASSPHRASE, Params::new(32, 3, 4, None).unwrap()).unwrap();
+        Encryptor::with_params(&[], PASSPHRASE, Params::new(32, 3, 4, None).unwrap()).unwrap();
     assert_eq!(cipher.out_len(), 156);
     let ciphertext = cipher.encrypt_to_vec();
     assert_eq!(ciphertext.len(), 156);
@@ -68,7 +68,7 @@ fn minimum_output_length() {
 #[test]
 fn magic_number() {
     let ciphertext =
-        Encryptor::with_params(TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
+        Encryptor::with_params(&TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
             .map(Encryptor::encrypt_to_vec)
             .unwrap();
     assert_eq!(&ciphertext[..7], b"abcrypt");
@@ -77,7 +77,7 @@ fn magic_number() {
 #[test]
 fn version() {
     let ciphertext =
-        Encryptor::with_params(TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
+        Encryptor::with_params(&TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
             .map(Encryptor::encrypt_to_vec)
             .unwrap();
     assert_eq!(ciphertext[7], 0);
@@ -86,7 +86,7 @@ fn version() {
 #[test]
 fn m_cost() {
     let ciphertext =
-        Encryptor::with_params(TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
+        Encryptor::with_params(&TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
             .map(Encryptor::encrypt_to_vec)
             .unwrap();
     assert_eq!(&ciphertext[8..12], u32::to_le_bytes(32));
@@ -95,7 +95,7 @@ fn m_cost() {
 #[test]
 fn t_cost() {
     let ciphertext =
-        Encryptor::with_params(TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
+        Encryptor::with_params(&TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
             .map(Encryptor::encrypt_to_vec)
             .unwrap();
     assert_eq!(&ciphertext[12..16], u32::to_le_bytes(3));
@@ -104,7 +104,7 @@ fn t_cost() {
 #[test]
 fn p_cost() {
     let ciphertext =
-        Encryptor::with_params(TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
+        Encryptor::with_params(&TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
             .map(Encryptor::encrypt_to_vec)
             .unwrap();
     assert_eq!(&ciphertext[16..20], u32::to_le_bytes(4));
@@ -113,7 +113,7 @@ fn p_cost() {
 #[test]
 fn out_len() {
     let cipher =
-        Encryptor::with_params(TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
+        Encryptor::with_params(&TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
             .unwrap();
     assert_eq!(cipher.out_len(), 170);
 }

--- a/crate/cli/src/app.rs
+++ b/crate/cli/src/app.rs
@@ -92,7 +92,7 @@ pub fn run() -> anyhow::Result<()> {
                     params::displayln(params.m_cost(), params.t_cost(), params.p_cost());
                 }
 
-                let cipher = match Decryptor::new(input, passphrase) {
+                let cipher = match Decryptor::new(&input, passphrase) {
                     c @ Err(abcrypt::Error::InvalidHeaderMac(_)) => {
                         c.context("passphrase is incorrect")
                     }


### PR DESCRIPTION
Change to store the plaintext and the ciphertext as `slice` in `Encryptor` and `Decryptor`.