### PR TITLE
Change `Encryptor::new` to require `alloc`

### DIFF
--- a/crate/abcrypt/src/encrypt.rs
+++ b/crate/abcrypt/src/encrypt.rs
@@ -34,16 +34,14 @@ impl<'m> Encryptor<'m> {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(feature = "alloc")]
-    /// # {
     /// # use abcrypt::Encryptor;
-    ///
+    /// #
     /// let data = b"Hello, world!\n";
     /// let passphrase = "passphrase";
     ///
     /// let cipher = Encryptor::new(data, passphrase).unwrap();
-    /// # }
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn new(plaintext: &'m impl AsRef<[u8]>, passphrase: impl AsRef<[u8]>) -> Result<Self> {
         Self::with_params(plaintext, passphrase, Params::default())
     }


### PR DESCRIPTION
When calculating a derived key based on the default Argon2 parameters created by `Params::default`, heap allocation is required.