### PR TITLE
Bump `argon2` from 0.5.1 to 0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "argon2"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e554a8638bdc1e4eae9984845306cc95f8a9208ba8d49c3859fd958b46774d"
+checksum = "17ba4cac0a46bc1d2912652a751c47f2a9f3a7fe89bcae2275d418f5270402f9"
 dependencies = [
  "base64ct",
  "blake2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ repository = "https://github.com/sorairolake/abcrypt"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[workspace.dependencies]
+anyhow = "1.0.75"
+clap = { version = "4.3.24", features = ["derive"] }
+dialoguer = { version = "0.10.4", default-features = false, features = ["password"] }
+
 [profile.release.package.abcrypt-cli]
 # The `lto` setting cannot be specified yet, see https://github.com/rust-lang/cargo/issues/9330
 # lto = true

--- a/crate/abcrypt/CHANGELOG.adoc
+++ b/crate/abcrypt/CHANGELOG.adoc
@@ -16,9 +16,10 @@ project adheres to https://semver.org/[Semantic Versioning].
 
 == {compare-url}/abcrypt-v0.2.0\...HEAD[Unreleased]
 
-=== Removed
+=== Changed
 
-* Remove links to the format specification ({pull-request-url}/38[#38])
+* Change `Params::m_cost`, `Params::t_cost` and `Params::p_cost` to `const fn`
+  ({pull-request-url}/44[#44])
 
 == {compare-url}/abcrypt-v0.1.0\...abcrypt-v0.2.0[0.2.0] - 2023-09-03
 

--- a/crate/abcrypt/Cargo.toml
+++ b/crate/abcrypt/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-argon2 = { version = "0.5.1", default-features = false }
+argon2 = { version = "0.5.2", default-features = false }
 blake2 = { version = "0.10.6", default-features = false }
 chacha20poly1305 = { version = "0.10.1", default-features = false, features = ["getrandom"] }
 rand = { version = "0.8.5", default-features = false, features = ["getrandom", "std_rng"] }

--- a/crate/abcrypt/Cargo.toml
+++ b/crate/abcrypt/Cargo.toml
@@ -32,9 +32,9 @@ chacha20poly1305 = { version = "0.10.1", default-features = false, features = ["
 rand = { version = "0.8.5", default-features = false, features = ["getrandom", "std_rng"] }
 
 [dev-dependencies]
-anyhow = "1.0.75"
-clap = { version = "4.3.24", features = ["derive"] }
-dialoguer = { version = "0.10.4", default-features = false, features = ["password"] }
+anyhow.workspace = true
+clap.workspace = true
+dialoguer.workspace = true
 
 [features]
 default = ["std"]

--- a/crate/abcrypt/src/params.rs
+++ b/crate/abcrypt/src/params.rs
@@ -50,7 +50,7 @@ impl Params {
     /// ```
     #[must_use]
     #[inline]
-    pub fn m_cost(&self) -> u32 {
+    pub const fn m_cost(&self) -> u32 {
         self.0.m_cost()
     }
 
@@ -68,7 +68,7 @@ impl Params {
     /// ```
     #[must_use]
     #[inline]
-    pub fn t_cost(&self) -> u32 {
+    pub const fn t_cost(&self) -> u32 {
         self.0.t_cost()
     }
 
@@ -86,7 +86,7 @@ impl Params {
     /// ```
     #[must_use]
     #[inline]
-    pub fn p_cost(&self) -> u32 {
+    pub const fn p_cost(&self) -> u32 {
         self.0.p_cost()
     }
 }

--- a/crate/cli/CHANGELOG.adoc
+++ b/crate/cli/CHANGELOG.adoc
@@ -19,6 +19,8 @@ project adheres to https://semver.org/[Semantic Versioning].
 === Changed
 
 * Change MSRV to 1.65.0 ({pull-request-url}/39[#39])
+* Change the maximum value of `--memory-size` to 4 TiB
+  ({pull-request-url}/44[#44])
 
 == {compare-url}/abcrypt-cli-v0.1.0\...abcrypt-cli-v0.2.0[0.2.0] - 2023-09-03
 

--- a/crate/cli/Cargo.toml
+++ b/crate/cli/Cargo.toml
@@ -29,12 +29,12 @@ path = "src/main.rs"
 
 [dependencies]
 abcrypt = { version = "0.2.0", path = "../abcrypt" }
-anyhow = "1.0.75"
+anyhow.workspace = true
 byte-unit = { version = "4.0.19", default-features = false, features = ["std"] }
-clap = { version = "4.3.24", features = ["derive", "wrap_help"] }
+clap = { workspace = true, features = ["wrap_help"] }
 clap_complete = "4.3.2"
 clap_complete_nushell = "4.3.2"
-dialoguer = { version = "0.10.4", default-features = false, features = ["password"] }
+dialoguer.workspace = true
 serde = { version = "1.0.188", features = ["derive"], optional = true }
 serde_json = { version = "1.0.105", optional = true }
 sysexits = "0.7.1"

--- a/crate/cli/doc/man/man1/abcrypt-encrypt.1.adoc
+++ b/crate/cli/doc/man/man1/abcrypt-encrypt.1.adoc
@@ -4,7 +4,7 @@
 
 = abcrypt-encrypt(1)
 // Specify in UTC.
-:docdate: 2023-08-26
+:docdate: 2023-09-05
 :doctype: manpage
 ifdef::revnumber[:mansource: abcrypt {revnumber}]
 :manmanual: General Commands Manual
@@ -42,7 +42,8 @@ _FILE_::
   the byte prefix (such as Ki and M). If only a numeric value is specified for
   _BYTE_, it is the same as specifying the symbol without the byte prefix. Note
   that _BYTE_ that is not multiples of 1 KiB is truncated toward zero to the
-  nearest it. _BYTE_ should be between *8 KiB* and *256 GiB*. Default is 19 MiB.
+  nearest it. _BYTE_ should be between *8 KiB* and *4294967295 KiB* (4 TiB).
+  Default is 19456 KiB (19 MiB).
 
 *-t*, *--iterations* _NUM_::
 

--- a/crate/cli/src/cli.rs
+++ b/crate/cli/src/cli.rs
@@ -13,7 +13,7 @@ use std::{
 
 use abcrypt::argon2::Params;
 use anyhow::anyhow;
-use byte_unit::{Byte, KIBIBYTE};
+use byte_unit::{Byte, ByteUnit, KIBIBYTE};
 use clap::{
     builder::{TypedValueParser, ValueParserFactory},
     value_parser, ArgGroup, Args, CommandFactory, Parser, Subcommand, ValueEnum, ValueHint,
@@ -301,7 +301,7 @@ impl Deref for MemorySize {
 impl fmt::Display for MemorySize {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Byte::from_bytes(u64::from(self.0) * KIBIBYTE)
-            .get_appropriate_unit(true)
+            .get_adjusted_unit(ByteUnit::KiB)
             .fmt(f)
     }
 }
@@ -319,7 +319,7 @@ impl FromStr for MemorySize {
             }
             _ => Err(anyhow!(
                 "{} is not in {}..={}",
-                Byte::from_bytes(byte).get_appropriate_unit(true),
+                Byte::from_bytes(byte).get_adjusted_unit(ByteUnit::KiB),
                 Self::MIN,
                 Self::MAX
             )),
@@ -463,8 +463,8 @@ mod tests {
     #[test]
     fn display_memory_size() {
         assert_eq!(format!("{}", MemorySize::MIN), "8.00 KiB");
-        assert_eq!(format!("{}", MemorySize::default()), "19.00 MiB");
-        assert_eq!(format!("{}", MemorySize::MAX), "256.00 GiB");
+        assert_eq!(format!("{}", MemorySize::default()), "19456.00 KiB");
+        assert_eq!(format!("{}", MemorySize::MAX), "4294967295.00 KiB");
     }
 
     #[test]
@@ -495,7 +495,7 @@ mod tests {
 
         assert_eq!(MemorySize::from_str("8 KiB").unwrap(), MemorySize::MIN);
         assert_eq!(
-            MemorySize::from_str("268435455 KiB").unwrap(),
+            MemorySize::from_str("4294967295 KiB").unwrap(),
             MemorySize::MAX
         );
     }
@@ -552,10 +552,10 @@ mod tests {
         assert!(MemorySize::from_str("7 KiB").is_err());
         assert_eq!(MemorySize::from_str("8 KiB").unwrap(), MemorySize::MIN);
         assert_eq!(
-            MemorySize::from_str("268435455 KiB").unwrap(),
+            MemorySize::from_str("4294967295 KiB").unwrap(),
             MemorySize::MAX
         );
-        assert!(MemorySize::from_str("268435456 KiB").is_err());
+        assert!(MemorySize::from_str("4294967296 KiB").is_err());
     }
 
     impl Iterations {

--- a/crate/cli/src/params.rs
+++ b/crate/cli/src/params.rs
@@ -32,7 +32,7 @@ pub struct Params {
 #[cfg(feature = "json")]
 impl Params {
     /// Creates a new `Params`.
-    pub fn new(params: &abcrypt::Params) -> Self {
+    pub const fn new(params: &abcrypt::Params) -> Self {
         Self {
             m: params.m_cost(),
             t: params.t_cost(),

--- a/crate/cli/tests/integration.rs
+++ b/crate/cli/tests/integration.rs
@@ -248,7 +248,7 @@ fn validate_m_parameter_ranges_for_encrypt_command() {
         .failure()
         .code(2)
         .stderr(predicate::str::contains(
-            "7.00 KiB is not in 8.00 KiB..=256.00 GiB",
+            "7.00 KiB is not in 8.00 KiB..=4294967295.00 KiB",
         ));
     command()
         .arg("encrypt")
@@ -266,7 +266,7 @@ fn validate_m_parameter_ranges_for_encrypt_command() {
     command()
         .arg("encrypt")
         .arg("-m")
-        .arg("268435456 KiB")
+        .arg("4294967296 KiB")
         .arg("--passphrase-from-stdin")
         .arg("-v")
         .arg("data/data.txt")
@@ -275,7 +275,7 @@ fn validate_m_parameter_ranges_for_encrypt_command() {
         .failure()
         .code(2)
         .stderr(predicate::str::contains(
-            "256.00 GiB is not in 8.00 KiB..=256.00 GiB",
+            "4294967296.00 KiB is not in 8.00 KiB..=4294967295.00 KiB",
         ));
 }
 


### PR DESCRIPTION
- Change to use the `workspace.dependencies` table.
- Change `Params::m_cost`, `Params::t_cost` and `Params::p_cost` to `const fn`.
- Change the maximum value of `--memory-size` to 4 TiB.