### PR TITLE
fix(capi): Change to use `extern "C-unwind"`

### DIFF
--- a/crates/capi/CHANGELOG.adoc
+++ b/crates/capi/CHANGELOG.adoc
@@ -19,6 +19,7 @@ project adheres to https://semver.org/[Semantic Versioning].
 === Changed
 
 * Re-enable `clang-format` and `clang-tidy` on CI ({pull-request-url}/384[#384])
+* Use `extern "C-unwind"` instead of `extern "C"` ({pull-request-url}/542[#542])
 
 == {compare-url}/abcrypt-capi-v0.3.1\...abcrypt-capi-v0.3.2[0.3.2] - 2024-04-16
 

--- a/crates/capi/include/abcrypt.h
+++ b/crates/capi/include/abcrypt.h
@@ -194,5 +194,5 @@ uint32_t abcrypt_params_time_cost(struct abcrypt_params *params);
 uint32_t abcrypt_params_parallelism(struct abcrypt_params *params);
 
 #ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/crates/capi/src/decrypt.rs
+++ b/crates/capi/src/decrypt.rs
@@ -35,7 +35,7 @@ use crate::ErrorCode;
 /// - `passphrase` and `passphrase_len`.
 /// - `out` and `out_len`.
 #[no_mangle]
-pub unsafe extern "C" fn abcrypt_decrypt(
+pub unsafe extern "C-unwind" fn abcrypt_decrypt(
     ciphertext: Option<NonNull<u8>>,
     ciphertext_len: usize,
     passphrase: Option<NonNull<u8>>,

--- a/crates/capi/src/encrypt.rs
+++ b/crates/capi/src/encrypt.rs
@@ -31,7 +31,7 @@ use crate::ErrorCode;
 /// - `passphrase` and `passphrase_len`.
 /// - `out` and `out_len`.
 #[no_mangle]
-pub unsafe extern "C" fn abcrypt_encrypt(
+pub unsafe extern "C-unwind" fn abcrypt_encrypt(
     plaintext: Option<NonNull<u8>>,
     plaintext_len: usize,
     passphrase: Option<NonNull<u8>>,
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn abcrypt_encrypt(
 /// - `passphrase` and `passphrase_len`.
 /// - `out` and `out_len`.
 #[no_mangle]
-pub unsafe extern "C" fn abcrypt_encrypt_with_params(
+pub unsafe extern "C-unwind" fn abcrypt_encrypt_with_params(
     plaintext: Option<NonNull<u8>>,
     plaintext_len: usize,
     passphrase: Option<NonNull<u8>>,

--- a/crates/capi/src/error.rs
+++ b/crates/capi/src/error.rs
@@ -119,7 +119,7 @@ impl From<Error> for ErrorCode {
 /// of `slice::from_raw_parts`.
 #[must_use]
 #[no_mangle]
-pub unsafe extern "C" fn abcrypt_error_message(
+pub unsafe extern "C-unwind" fn abcrypt_error_message(
     error_code: ErrorCode,
     buf: Option<NonNull<u8>>,
     buf_len: usize,
@@ -129,7 +129,7 @@ pub unsafe extern "C" fn abcrypt_error_message(
 
 /// Returns the number of output bytes of the error message.
 #[no_mangle]
-pub extern "C" fn abcrypt_error_message_out_len(error_code: ErrorCode) -> usize {
+pub extern "C-unwind" fn abcrypt_error_message_out_len(error_code: ErrorCode) -> usize {
     error_code.error_message_out_len()
 }
 

--- a/crates/capi/src/params.rs
+++ b/crates/capi/src/params.rs
@@ -155,7 +155,7 @@ impl From<abcrypt::Params> for Params {
 #[must_use]
 #[no_mangle]
 #[inline]
-pub extern "C" fn abcrypt_params_new() -> Option<NonNull<Params>> {
+pub extern "C-unwind" fn abcrypt_params_new() -> Option<NonNull<Params>> {
     Params::new()
 }
 
@@ -166,7 +166,7 @@ pub extern "C" fn abcrypt_params_new() -> Option<NonNull<Params>> {
 /// This must not violate the safety conditions of `Box::from_raw`.
 #[no_mangle]
 #[inline]
-pub unsafe extern "C" fn abcrypt_params_free(params: Option<NonNull<Params>>) {
+pub unsafe extern "C-unwind" fn abcrypt_params_free(params: Option<NonNull<Params>>) {
     Params::free(params);
 }
 
@@ -188,7 +188,7 @@ pub unsafe extern "C" fn abcrypt_params_free(params: Option<NonNull<Params>>) {
 /// safety conditions of `slice::from_raw_parts`.
 #[must_use]
 #[no_mangle]
-pub unsafe extern "C" fn abcrypt_params_read(
+pub unsafe extern "C-unwind" fn abcrypt_params_read(
     ciphertext: Option<NonNull<u8>>,
     ciphertext_len: usize,
     params: Option<NonNull<Params>>,
@@ -202,7 +202,7 @@ pub unsafe extern "C" fn abcrypt_params_read(
 #[must_use]
 #[no_mangle]
 #[inline]
-pub extern "C" fn abcrypt_params_memory_cost(params: Option<NonNull<Params>>) -> u32 {
+pub extern "C-unwind" fn abcrypt_params_memory_cost(params: Option<NonNull<Params>>) -> u32 {
     Params::memory_cost(params)
 }
 
@@ -212,7 +212,7 @@ pub extern "C" fn abcrypt_params_memory_cost(params: Option<NonNull<Params>>) ->
 #[must_use]
 #[no_mangle]
 #[inline]
-pub extern "C" fn abcrypt_params_time_cost(params: Option<NonNull<Params>>) -> u32 {
+pub extern "C-unwind" fn abcrypt_params_time_cost(params: Option<NonNull<Params>>) -> u32 {
     Params::time_cost(params)
 }
 
@@ -222,7 +222,7 @@ pub extern "C" fn abcrypt_params_time_cost(params: Option<NonNull<Params>>) -> u
 #[must_use]
 #[no_mangle]
 #[inline]
-pub extern "C" fn abcrypt_params_parallelism(params: Option<NonNull<Params>>) -> u32 {
+pub extern "C-unwind" fn abcrypt_params_parallelism(params: Option<NonNull<Params>>) -> u32 {
     Params::parallelism(params)
 }
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
This is because the behavior of `extern "C"` functions has changed since Rust 1.81.0.

See <https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html#abort-on-uncaught-panics-in-extern-c-functions>.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #505

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/abcrypt/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/abcrypt/blob/develop/CODE_OF_CONDUCT.md
