### PR TITLE
feat: Make `Error` trait available in `no_std` mode

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -24,7 +24,7 @@ jobs:
           - aarch64-apple-darwin
           - x86_64-pc-windows-msvc
         toolchain:
-          - 1.74.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
         include:
           - target: x86_64-unknown-linux-gnu
@@ -66,7 +66,7 @@ jobs:
           - aarch64-apple-darwin
           - x86_64-pc-windows-msvc
         toolchain:
-          - 1.74.0
+          - 1.81.0
           - stable
         include:
           - target: x86_64-unknown-linux-gnu
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.74.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
     steps:
       - name: Checkout code
@@ -139,7 +139,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.74.0
+          - 1.81.0
           - stable
     steps:
       - name: Checkout code
@@ -171,7 +171,7 @@ jobs:
           - macos-14
           - windows-2022
         rust-version:
-          - 1.74.0
+          - 1.81.0
           - stable
         python-version:
           - "3.8"
@@ -292,7 +292,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.74.0
+          - 1.81.0
           - stable
     steps:
       - name: Checkout code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = ["crates/*"]
 [workspace.package]
 authors = ["Shun Sakai <sorairolake@protonmail.ch>"]
 edition = "2021"
-rust-version = "1.74.0"
+rust-version = "1.81.0"
 homepage = "https://sorairolake.github.io/abcrypt/"
 repository = "https://github.com/sorairolake/abcrypt"
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-msrv = "1.74.0"
+msrv = "1.81.0"

--- a/crates/abcrypt/CHANGELOG.adoc
+++ b/crates/abcrypt/CHANGELOG.adoc
@@ -14,6 +14,13 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/abcrypt-v0.3.7\...HEAD[Unreleased]
+
+=== Changed
+
+* Make `Error` trait available in `no_std` mode ({pull-request-url}/556[#556])
+* Bump MSRV to 1.81.0 ({pull-request-url}/556[#556])
+
 == {compare-url}/abcrypt-v0.3.6\...abcrypt-v0.3.7[0.3.7] - 2024-10-19
 
 === Fixed

--- a/crates/abcrypt/README.md
+++ b/crates/abcrypt/README.md
@@ -52,7 +52,7 @@ See the [documentation][docs-url] for more details.
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version (MSRV) of this library is v1.74.0.
+The minimum supported Rust version (MSRV) of this library is v1.81.0.
 
 ## Source code
 

--- a/crates/abcrypt/src/error.rs
+++ b/crates/abcrypt/src/error.rs
@@ -4,7 +4,7 @@
 
 //! Error types for this crate.
 
-use core::{fmt, result};
+use core::{error, fmt, result};
 
 use blake2::digest::MacError;
 
@@ -48,10 +48,9 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {
+impl error::Error for Error {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             Self::InvalidArgon2Params(err) | Self::InvalidArgon2Context(err) => Some(err),
             Self::InvalidHeaderMac(err) => Some(err),
@@ -411,10 +410,9 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn source() {
-        use std::error::Error as _;
+        use error::Error as _;
 
         assert!(Error::InvalidLength.source().is_none());
         assert!(Error::InvalidMagicNumber.source().is_none());

--- a/crates/abcrypt/src/lib.rs
+++ b/crates/abcrypt/src/lib.rs
@@ -95,8 +95,6 @@
 #[cfg(feature = "alloc")]
 #[macro_use]
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std;
 
 mod decrypt;
 mod encrypt;

--- a/crates/capi/CHANGELOG.adoc
+++ b/crates/capi/CHANGELOG.adoc
@@ -20,6 +20,7 @@ project adheres to https://semver.org/[Semantic Versioning].
 
 * Re-enable `clang-format` and `clang-tidy` on CI ({pull-request-url}/384[#384])
 * Use `extern "C-unwind"` instead of `extern "C"` ({pull-request-url}/542[#542])
+* Bump MSRV to 1.81.0 ({pull-request-url}/556[#556])
 
 == {compare-url}/abcrypt-capi-v0.3.1\...abcrypt-capi-v0.3.2[0.3.2] - 2024-04-16
 

--- a/crates/capi/README.md
+++ b/crates/capi/README.md
@@ -42,7 +42,7 @@ fd -t directory out ./target/*/build/abcrypt-capi-*
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version (MSRV) of this library is v1.74.0.
+The minimum supported Rust version (MSRV) of this library is v1.81.0.
 
 ## Source code
 

--- a/crates/cli/BUILD.adoc
+++ b/crates/cli/BUILD.adoc
@@ -7,7 +7,7 @@
 == Prerequisites
 
 .To build *abcrypt*, you will need the following dependencies
-* https://doc.rust-lang.org/stable/cargo/[Cargo] (v1.74.0 or later)
+* https://doc.rust-lang.org/stable/cargo/[Cargo] (v1.81.0 or later)
 
 .To build man pages, you will need the following additional dependencies
 * https://asciidoctor.org/[Asciidoctor]

--- a/crates/cli/CHANGELOG.adoc
+++ b/crates/cli/CHANGELOG.adoc
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/abcrypt-cli-v0.3.3\...HEAD[Unreleased]
+
+=== Changed
+
+* Bump MSRV to 1.81.0 ({pull-request-url}/556[#556])
+
 == {compare-url}/abcrypt-cli-v0.3.2\...abcrypt-cli-v0.3.3[0.3.3] - 2024-08-04
 
 === Changed

--- a/crates/python/CHANGELOG.adoc
+++ b/crates/python/CHANGELOG.adoc
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/abcrypt-py-v0.1.4\...HEAD[Unreleased]
+
+=== Changed
+
+* Bump MSRV to 1.81.0 ({pull-request-url}/556[#556])
+
 == {compare-url}/abcrypt-py-v0.1.3\...abcrypt-py-v0.1.4[0.1.4] - 2024-03-17
 
 === Fixed

--- a/crates/python/README.md
+++ b/crates/python/README.md
@@ -32,7 +32,7 @@ See the [documentation][docs-url] for more details.
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version (MSRV) of this library is v1.74.0.
+The minimum supported Rust version (MSRV) of this library is v1.81.0.
 
 ## Development
 

--- a/crates/wasm/CHANGELOG.adoc
+++ b/crates/wasm/CHANGELOG.adoc
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/abcrypt-wasm-v0.3.2\...HEAD[Unreleased]
+
+=== Changed
+
+* Bump MSRV to 1.81.0 ({pull-request-url}/556[#556])
+
 == {compare-url}/abcrypt-wasm-v0.3.1\...abcrypt-wasm-v0.3.2[0.3.2] - 2024-02-28
 
 === Changed

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -41,7 +41,7 @@ See the [documentation][docs-url] for more details.
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version (MSRV) of this library is v1.74.0.
+The minimum supported Rust version (MSRV) of this library is v1.81.0.
 
 ## Source code
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Merging this requires that the low-level error types implement [`core::error::Error`](https://doc.rust-lang.org/core/error/trait.Error.html) trait.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #543

## Additional context

<!-- If you have any other context, describe them here. -->
Wait until at least Rust 1.83 is released before merging this.

## Checklist

- [x] I have read the [Contribution Guide].
- [x] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/abcrypt/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/abcrypt/blob/develop/CODE_OF_CONDUCT.md
