### PR TITLE
fix: Change the parameter type of `Encryptor::encrypt` and `Decryptor::decrypt`

### DIFF
--- a/crates/abcrypt/CHANGELOG.adoc
+++ b/crates/abcrypt/CHANGELOG.adoc
@@ -14,6 +14,13 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/abcrypt-v0.3.6\...HEAD[Unreleased]
+
+=== Fixed
+
+* Change `Encryptor::encrypt` and `Decryptor::decrypt` to take the buffer to
+  write to as a mutable reference ({pull-request-url}/579[#579])
+
 == {compare-url}/abcrypt-v0.3.5\...abcrypt-v0.3.6[0.3.6] - 2024-07-31
 
 === Added

--- a/crates/abcrypt/src/decrypt.rs
+++ b/crates/abcrypt/src/decrypt.rs
@@ -110,7 +110,7 @@ impl<'c> Decryptor<'c> {
     /// cipher.decrypt(&mut buf).unwrap();
     /// # assert_eq!(buf, data.as_slice());
     /// ```
-    pub fn decrypt(&self, mut buf: impl AsMut<[u8]>) -> Result<()> {
+    pub fn decrypt(&self, buf: &mut (impl AsMut<[u8]> + ?Sized)) -> Result<()> {
         let inner = |decryptor: &Self, buf: &mut [u8]| -> Result<()> {
             buf.copy_from_slice(decryptor.ciphertext);
 

--- a/crates/abcrypt/src/encrypt.rs
+++ b/crates/abcrypt/src/encrypt.rs
@@ -127,7 +127,7 @@ impl<'m> Encryptor<'m> {
     /// cipher.encrypt(&mut buf);
     /// # assert_ne!(buf, data.as_slice());
     /// ```
-    pub fn encrypt(&self, mut buf: impl AsMut<[u8]>) {
+    pub fn encrypt(&self, buf: &mut (impl AsMut<[u8]> + ?Sized)) {
         let inner = |encryptor: &Self, buf: &mut [u8]| {
             buf[..HEADER_SIZE].copy_from_slice(&encryptor.header.as_bytes());
             let body = &mut buf[HEADER_SIZE..(self.out_len() - TAG_SIZE)];


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Change to take the buffer to write to as a mutable reference.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/abcrypt/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/abcrypt/blob/develop/CODE_OF_CONDUCT.md
