### PR TITLE
feat!: Use pass-by-value with types that implement `Copy`

### DIFF
--- a/crates/abcrypt/CHANGELOG.adoc
+++ b/crates/abcrypt/CHANGELOG.adoc
@@ -19,6 +19,10 @@ project adheres to https://semver.org/[Semantic Versioning].
 === Changed
 
 * Bump MSRV to 1.88.0 ({pull-request-url}/886[#886])
+* Change getters for types that implement the `Copy` trait to pass-by-value
+  ({pull-request-url}/974[#974])
+* Change to consume instances when encrypting and decrypting
+  ({pull-request-url}/974[#974])
 
 == {compare-url}/abcrypt-v0.4.0\...abcrypt-v0.5.0[0.5.0] - 2025-07-28
 

--- a/crates/abcrypt/benches/decrypt.rs
+++ b/crates/abcrypt/benches/decrypt.rs
@@ -17,7 +17,7 @@ static TEST_DATA_ENC: &[u8] = include_bytes!("../tests/data/v1/argon2id/v0x13/da
 fn decrypt(b: &mut Bencher) {
     b.iter(|| {
         Decryptor::new(&TEST_DATA_ENC, PASSPHRASE)
-            .and_then(|c| c.decrypt_to_vec())
+            .and_then(Decryptor::decrypt_to_vec)
             .unwrap()
     });
 }

--- a/crates/abcrypt/benches/encrypt.rs
+++ b/crates/abcrypt/benches/encrypt.rs
@@ -16,7 +16,7 @@ const TEST_DATA: &[u8] = include_bytes!("../tests/data/data.txt");
 fn encrypt(b: &mut Bencher) {
     b.iter(|| {
         Encryptor::with_params(&TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
-            .map(|c| c.encrypt_to_vec())
+            .map(Encryptor::encrypt_to_vec)
             .unwrap()
     });
 }

--- a/crates/abcrypt/src/argon2_context.rs
+++ b/crates/abcrypt/src/argon2_context.rs
@@ -62,7 +62,7 @@ impl Argon2 {
     /// assert_eq!(argon2.variant(), Algorithm::Argon2id);
     /// ```
     #[must_use]
-    pub const fn variant(&self) -> Algorithm {
+    pub const fn variant(self) -> Algorithm {
         self.variant
     }
 
@@ -79,7 +79,7 @@ impl Argon2 {
     /// assert_eq!(argon2.version(), Version::V0x13);
     /// ```
     #[must_use]
-    pub const fn version(&self) -> argon2::Version {
+    pub const fn version(self) -> argon2::Version {
         self.version
     }
 }

--- a/crates/abcrypt/src/decrypt.rs
+++ b/crates/abcrypt/src/decrypt.rs
@@ -120,8 +120,8 @@ impl<'c> Decryptor<'c> {
     /// cipher.decrypt(&mut buf).unwrap();
     /// # assert_eq!(buf, *data);
     /// ```
-    pub fn decrypt<B: AsMut<[u8]> + ?Sized>(&self, buf: &mut B) -> Result<()> {
-        let inner = |decryptor: &Self, buf: &mut [u8]| -> Result<()> {
+    pub fn decrypt<B: AsMut<[u8]> + ?Sized>(self, buf: &mut B) -> Result<()> {
+        let inner = |decryptor: Self, buf: &mut [u8]| -> Result<()> {
             buf.copy_from_slice(decryptor.ciphertext);
 
             let cipher = XChaCha20Poly1305::new(&decryptor.dk.encrypt());
@@ -157,7 +157,7 @@ impl<'c> Decryptor<'c> {
     /// # assert_eq!(plaintext, data);
     /// ```
     #[cfg(feature = "alloc")]
-    pub fn decrypt_to_vec(&self) -> Result<Vec<u8>> {
+    pub fn decrypt_to_vec(self) -> Result<Vec<u8>> {
         let mut buf = vec![u8::default(); self.out_len()];
         self.decrypt(&mut buf)?;
         Ok(buf)
@@ -214,5 +214,5 @@ impl<'c> Decryptor<'c> {
 /// ```
 #[cfg(feature = "alloc")]
 pub fn decrypt(ciphertext: impl AsRef<[u8]>, passphrase: impl AsRef<[u8]>) -> Result<Vec<u8>> {
-    Decryptor::new(&ciphertext, passphrase).and_then(|c| c.decrypt_to_vec())
+    Decryptor::new(&ciphertext, passphrase).and_then(Decryptor::decrypt_to_vec)
 }

--- a/crates/abcrypt/src/encrypt.rs
+++ b/crates/abcrypt/src/encrypt.rs
@@ -189,17 +189,17 @@ impl<'m> Encryptor<'m> {
     /// cipher.encrypt(&mut buf);
     /// # assert_ne!(buf.as_slice(), data);
     /// ```
-    pub fn encrypt<B: AsMut<[u8]> + ?Sized>(&self, buf: &mut B) {
-        let inner = |encryptor: &Self, buf: &mut [u8]| {
+    pub fn encrypt<B: AsMut<[u8]> + ?Sized>(self, buf: &mut B) {
+        let inner = |encryptor: Self, buf: &mut [u8]| {
             buf[..HEADER_SIZE].copy_from_slice(&encryptor.header.as_bytes());
-            let payload = &mut buf[HEADER_SIZE..(self.out_len() - TAG_SIZE)];
+            let payload = &mut buf[HEADER_SIZE..(encryptor.out_len() - TAG_SIZE)];
             payload.copy_from_slice(encryptor.plaintext);
 
             let cipher = XChaCha20Poly1305::new(&encryptor.dk.encrypt());
             let tag = cipher
                 .encrypt_in_place_detached(&encryptor.header.nonce(), AAD, payload)
                 .expect("data too long");
-            buf[(self.out_len() - TAG_SIZE)..].copy_from_slice(&tag);
+            buf[(encryptor.out_len() - TAG_SIZE)..].copy_from_slice(&tag);
         };
         inner(self, buf.as_mut());
     }
@@ -221,7 +221,7 @@ impl<'m> Encryptor<'m> {
     /// ```
     #[cfg(feature = "alloc")]
     #[must_use]
-    pub fn encrypt_to_vec(&self) -> Vec<u8> {
+    pub fn encrypt_to_vec(self) -> Vec<u8> {
         let mut buf = vec![u8::default(); self.out_len()];
         self.encrypt(&mut buf);
         buf
@@ -276,7 +276,7 @@ impl<'m> Encryptor<'m> {
 /// [OWASP Password Storage Cheat Sheet]: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id
 #[cfg(feature = "alloc")]
 pub fn encrypt(plaintext: impl AsRef<[u8]>, passphrase: impl AsRef<[u8]>) -> Result<Vec<u8>> {
-    Encryptor::new(&plaintext, passphrase).map(|c| c.encrypt_to_vec())
+    Encryptor::new(&plaintext, passphrase).map(Encryptor::encrypt_to_vec)
 }
 
 /// Encrypts `plaintext` with the specified [`Params`] and into a newly
@@ -310,7 +310,7 @@ pub fn encrypt_with_params(
     passphrase: impl AsRef<[u8]>,
     params: Params,
 ) -> Result<Vec<u8>> {
-    Encryptor::with_params(&plaintext, passphrase, params).map(|c| c.encrypt_to_vec())
+    Encryptor::with_params(&plaintext, passphrase, params).map(Encryptor::encrypt_to_vec)
 }
 
 /// Encrypts `plaintext` with the specified [`Algorithm`], [`Version`] and
@@ -346,5 +346,5 @@ pub fn encrypt_with_context(
     params: Params,
 ) -> Result<Vec<u8>> {
     Encryptor::with_context(&plaintext, passphrase, argon2_type, argon2_version, params)
-        .map(|c| c.encrypt_to_vec())
+        .map(Encryptor::encrypt_to_vec)
 }

--- a/crates/abcrypt/src/params.rs
+++ b/crates/abcrypt/src/params.rs
@@ -64,7 +64,7 @@ impl Params {
     /// assert_eq!(params.memory_cost(), 32);
     /// ```
     #[must_use]
-    pub const fn memory_cost(&self) -> u32 {
+    pub const fn memory_cost(self) -> u32 {
         self.memory_cost
     }
 
@@ -81,7 +81,7 @@ impl Params {
     /// assert_eq!(params.time_cost(), 3);
     /// ```
     #[must_use]
-    pub const fn time_cost(&self) -> u32 {
+    pub const fn time_cost(self) -> u32 {
         self.time_cost
     }
 
@@ -98,7 +98,7 @@ impl Params {
     /// assert_eq!(params.parallelism(), 4);
     /// ```
     #[must_use]
-    pub const fn parallelism(&self) -> u32 {
+    pub const fn parallelism(self) -> u32 {
         self.parallelism
     }
 }

--- a/crates/abcrypt/tests/decrypt.rs
+++ b/crates/abcrypt/tests/decrypt.rs
@@ -80,7 +80,7 @@ fn success() {
 #[test]
 fn success_to_vec() {
     let plaintext = Decryptor::new(&TEST_DATA_ENC, PASSPHRASE)
-        .and_then(|c| c.decrypt_to_vec())
+        .and_then(Decryptor::decrypt_to_vec)
         .unwrap();
     assert_eq!(plaintext, TEST_DATA);
 }

--- a/crates/abcrypt/tests/encrypt.rs
+++ b/crates/abcrypt/tests/encrypt.rs
@@ -233,7 +233,7 @@ fn success_with_context() {
 fn success_to_vec() {
     let ciphertext =
         Encryptor::with_params(&TEST_DATA, PASSPHRASE, Params::new(32, 3, 4, None).unwrap())
-            .map(|c| c.encrypt_to_vec())
+            .map(Encryptor::encrypt_to_vec)
             .unwrap();
     assert_ne!(ciphertext, TEST_DATA);
     assert_eq!(ciphertext.len(), TEST_DATA.len() + HEADER_SIZE + TAG_SIZE);
@@ -244,7 +244,7 @@ fn success_to_vec() {
     assert_eq!(params.parallelism(), 4);
 
     let plaintext = Decryptor::new(&ciphertext, PASSPHRASE)
-        .and_then(|c| c.decrypt_to_vec())
+        .and_then(Decryptor::decrypt_to_vec)
         .unwrap();
     assert_eq!(plaintext, TEST_DATA);
 }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
These types implement the `Copy` trait, and are small enough to be more efficient to always pass by value.

Also, I think `Encryptor` and `Decryptor` should be consumed when encrypting and decrypting, so I change them to consume them.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/abcrypt/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/abcrypt/blob/develop/CODE_OF_CONDUCT.md
